### PR TITLE
fix unbuffered I/O related error

### DIFF
--- a/daemon/runner.py
+++ b/daemon/runner.py
@@ -85,8 +85,7 @@ class DaemonRunner(object):
         self.daemon_context = DaemonContext()
         self.daemon_context.stdin = open(app.stdin_path, 'r')
         self.daemon_context.stdout = open(app.stdout_path, 'w+')
-        self.daemon_context.stderr = open(
-            app.stderr_path, 'w+', buffering=0)
+        self.daemon_context.stderr = open(app.stderr_path, 'w+')
 
         self.pidfile = None
         if app.pidfile_path is not None:


### PR DESCRIPTION
Hi, I encountered an error as:

```
  File "/path/to/packages/daemon/runner.py", line 89, in __init__
    app.stderr_path, 'w+', buffering=0)
ValueError: can't have unbuffered text I/O
```

"w+" is not actually unbuffered as discussed [HERE](http://bugs.python.org/issue17404), so I have removed the `buffering` option.
